### PR TITLE
feat: Validate semantic PR action

### DIFF
--- a/.github/workflows/validate-semantic-pr.yml
+++ b/.github/workflows/validate-semantic-pr.yml
@@ -1,0 +1,31 @@
+name: "Lint PR"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+permissions:
+  pull-requests: read
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            build
+            chore
+            ci
+            docs
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+          validateSingleCommit: true


### PR DESCRIPTION
This action validates that PR titles follow the [Conventional Commits spec](https://www.conventionalcommits.org/). If the PR consists of a single commit, it will also check if the commit matches the convention.

Example:
- Valid: `feat: Validate sematic PR action`
- Invalid: `Validate sematic PR action` 

Part of: #2 