### PR TITLE
docs: Add Sonarcloud badges and commit guidelines to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Backend
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SE2Project-BHKPTZ_backend&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SE2Project-BHKPTZ_backend)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=SE2Project-BHKPTZ_backend&metric=coverage)](https://sonarcloud.io/summary/new_code?id=SE2Project-BHKPTZ_backend)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=SE2Project-BHKPTZ_backend&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=SE2Project-BHKPTZ_backend)
+
 ## Configure environment variables
 
 To run the projects you need to set the following environment variables (in an `.env` file for example):
@@ -46,3 +50,31 @@ The following tools can be useful when debugging SocketIO:
 
 - [Online connection checker](https://amritb.github.io/socketio-client-tool/)
 - The Admin UI that is hosted on http://localhost:53212/sioadmin
+
+## Contribution
+
+This project follows the [conventional commit guidelines](https://www.conventionalcommits.org/en/v1.0.0/) and also enforces semantic PR titles to maintain a clear and understandable project history.
+
+### Commit/PR Types and Scopes
+
+For an up-to-date list of commit and PR types and their scopes, please refer to [this](https://github.com/SE2Project-BHKPTZ/frontend/blob/main/.github/workflows/validate-semantic-pr.yml).
+
+#### Commit/PR Types Include:
+
+- `feat`: Introduction of a new feature.
+- `fix`: A bug correction.
+- `build`: Modifications that affect the build system or external dependencies.
+- `chore`: Miscellaneous changes that don't modify source or test files.
+- `ci`: Adjustments to our CI configuration files and scripts.
+- `docs`: Documentation updates.
+- `perf`: Changes that enhance performance.
+- `refactor`: Code alterations that neither fix a bug nor introduce a feature.
+- `revert`: Undoing a previous commit.
+- `style`: Changes that do not impact the code's meaning (white-space, formatting, etc.).
+- `test`: Adding missing tests or correcting existing ones.
+
+Example Commit and PR Title:
+
+```
+feat: Add login and register activities
+```


### PR DESCRIPTION
## This PR

- Adds SonarCloud quality gates and coverage badges to the `README`
- Adds documentation for the commit and PR guidelines