### PR TITLE
feat: Update lobby status and check for duplicated names

### DIFF
--- a/src/services/lobby.service.js
+++ b/src/services/lobby.service.js
@@ -4,6 +4,8 @@ const userService = require('./user.service');
 
 const getByLobbyID = async (lobbyid) => Lobby.findOne({ lobbyid });
 
+const getLobbyByName = async (name) => Lobby.findOne({ name });
+
 const getRandomString = async (len) => {
   const arr = '123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   let ans = '';
@@ -43,6 +45,12 @@ exports.delete = async (uuid) => Lobby.deleteOne({ uuid: uuid.toString() }).then
 
 exports.create = async (name, isPublic, maxPlayers, playerUUID) => new Promise(
   (resolve, reject) => {
+    getLobbyByName(name).then((lobbyWithName) => {
+      if (lobbyWithName != null) {
+        reject(new Error('Lobby with name already exists'));
+      }
+    });
+
     isPlayerInLobby(playerUUID).then(async (data) => {
       if (data != null) {
         reject(new Error('Player is already in an lobby'));
@@ -144,6 +152,18 @@ exports.kick = async (adminUUID, playerUUID) => new Promise(
     });
   },
 );
+
+exports.updateLobbyStatus = async (lobbyId, status) => {
+  const lobby = await getByLobbyID(lobbyId);
+  if (!lobby) {
+    throw new Error('Lobby not found');
+  }
+
+  lobby.status = status;
+  await lobby.save();
+
+  return lobby;
+};
 
 exports.exportedForTesting = {
   getRandomString,

--- a/src/services/lobby.service.test.js
+++ b/src/services/lobby.service.test.js
@@ -257,6 +257,6 @@ describe('Function updateLobbyStatus', () => {
   it('should throw error if lobby is not found', async () => {
     Lobby.findOne = jest.fn().mockResolvedValue(null);
 
-    expect(updateLobbyStatus('12345', 'RUNNING')).rejects.toThrow('Lobby not found');
+    await expect(updateLobbyStatus('12345', 'RUNNING')).rejects.toThrow('Lobby not found');
   });
 });

--- a/src/services/lobby.service.test.js
+++ b/src/services/lobby.service.test.js
@@ -153,7 +153,7 @@ describe('Function leave', () => {
     const mockLobby = {
       uuid: 'uuid',
       players: [{ uuid: 'testPlayerUUID', username: 'testuser' }, { uuid: 'testPlayerUUID2', username: 'testuser2' }],
-      save: jest.fn(),
+      save: jest.fn().mockResolvedValueOnce(),
     };
 
     Lobby.findOne = jest.fn().mockResolvedValueOnce(mockLobby);
@@ -185,7 +185,7 @@ describe('Function kick', () => {
     const mockLobby = {
       uuid: 'uuid',
       players: [{ uuid: 'testPlayerUUID', username: 'testuser' }, { uuid: 'testPlayerUUID2', username: 'testuser2' }],
-      save: jest.fn(),
+      save: jest.fn().mockResolvedValueOnce(),
     };
 
     Lobby.findOne = jest.fn().mockResolvedValue(mockLobby);
@@ -219,7 +219,7 @@ describe('Function kick', () => {
     const mockLobby = {
       uuid: 'uuid',
       players: [{}, { uuid: 'testPlayerUUID', username: 'testuser' }],
-      save: jest.fn(),
+      save: jest.fn().mockResolvedValueOnce(),
     };
 
     Lobby.findOne = jest.fn().mockResolvedValue(mockLobby);

--- a/src/socketHandler/gameHandler.js
+++ b/src/socketHandler/gameHandler.js
@@ -15,13 +15,19 @@ const {
   getPlayersScores,
 } = require('../services/gamestate.service');
 const { startRound, getWinningCard } = require('../services/game.service');
-const { getCurrentLobby } = require('../services/lobby.service');
+const { getCurrentLobby, updateLobbyStatus } = require('../services/lobby.service');
 const { getByWebsocket } = require('../services/user.service');
 const Card = require('../utils/card.model');
 
 const startGame = async function (socket, io) {
   const user = await getByWebsocket(socket.id);
   const lobby = await getCurrentLobby(user.uuid);
+
+  try {
+    await updateLobbyStatus(lobby.lobbyid, 'RUNNING');
+  } catch (e) {
+    console.log(`Error while updating lobby status: ${e}`);
+  }
 
   createGame(lobby.lobbyid, lobby.players);
 


### PR DESCRIPTION
## This PR

- Updates the lobby status to `RUNNING` when the game is started
- Checks if a lobby with the same name already exists