### PR TITLE
fix: Lobby reconnecting bug

### DIFF
--- a/src/services/lobby.service.js
+++ b/src/services/lobby.service.js
@@ -20,7 +20,7 @@ const getRandomString = async (len) => {
   return ans;
 };
 
-const isPlayerInLobby = async (uuid) => Lobby.findOne({ 'players.uuid': uuid.toString() });
+const isPlayerInLobby = async (uuid) => Lobby.findOne({ 'players.uuid': uuid.toString(), status: ['RUNNING', 'CREATED'] });
 
 exports.getPublic = async () => Lobby.find({ isPublic: true });
 

--- a/src/socketHandler/gameHandler.js
+++ b/src/socketHandler/gameHandler.js
@@ -111,6 +111,9 @@ const cardPlayed = async function (socket, io, payload) {
 
     io.to(lobbyId).emit('endGame', getPlayersScores(lobbyId));
     await leave(player.uuid);
+
+    await updateLobbyStatus(lobbyId, 'FINISHED');
+    socket.leave(lobbyId);
   } catch (err) {
     console.log(err.message);
   }


### PR DESCRIPTION
When the game was finished and the user restarted the app, it falsely started a recovery and moved the player back into the lobby since the lobby state was still in `RUNNING` instead of `FINISHED`. 

## This PR

- Updates the lobby status to `FINISHED` when the game is done
- Leaves from the SocketIO room